### PR TITLE
Enable double click editing for text fields

### DIFF
--- a/src/app/api/entries/[id]/route.ts
+++ b/src/app/api/entries/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getEntryById } from '@/lib/db';
+import { getEntryById, updateEntry } from '@/lib/db';
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -18,6 +18,39 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(entry);
   } catch (error) {
     console.error('Error fetching entry:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  const { id } = await params;
+
+  try {
+    const updates = await request.json();
+    
+    // Validate that only allowed fields are being updated
+    const allowedFields = ['gloss', 'lemmas', 'examples'];
+    const updateData: any = {};
+    
+    for (const [key, value] of Object.entries(updates)) {
+      if (allowedFields.includes(key)) {
+        updateData[key] = value;
+      }
+    }
+
+    if (Object.keys(updateData).length === 0) {
+      return NextResponse.json({ error: 'No valid fields to update' }, { status: 400 });
+    }
+
+    const updatedEntry = await updateEntry(id, updateData);
+    
+    if (!updatedEntry) {
+      return NextResponse.json({ error: 'Entry not found' }, { status: 404 });
+    }
+
+    return NextResponse.json(updatedEntry);
+  } catch (error) {
+    console.error('Error updating entry:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -41,6 +41,27 @@ export async function searchEntries(query: string, limit = 20): Promise<SearchRe
   return results;
 }
 
+export async function updateEntry(id: string, updates: Partial<Pick<LexicalEntry, 'gloss' | 'lemmas' | 'examples'>>): Promise<EntryWithRelations | null> {
+  const updatedEntry = await prisma.lexicalEntry.update({
+    where: { id },
+    data: updates,
+    include: {
+      sourceRelations: {
+        include: {
+          target: true
+        }
+      },
+      targetRelations: {
+        include: {
+          source: true
+        }
+      }
+    }
+  });
+
+  return updatedEntry;
+}
+
 export async function getGraphNode(entryId: string): Promise<GraphNode | null> {
   const entry = await getEntryById(entryId);
   if (!entry) return null;


### PR DESCRIPTION
Add double-click editing functionality to Lemmas, Definition, and Examples fields in WordNetExplorer to allow direct modification of entry data.

---
<a href="https://cursor.com/background-agent?bcId=bc-73ef4ba0-5a29-499f-bb73-5594ea1daac8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-73ef4ba0-5a29-499f-bb73-5594ea1daac8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

